### PR TITLE
Implement RGB overlay operation

### DIFF
--- a/ios/Classes/bitmap.cpp
+++ b/ios/Classes/bitmap.cpp
@@ -145,3 +145,29 @@ void adjust_color(
    }
    return;
 }
+
+/**
+ * RGB overlay
+ * Receives a RGB color and an overlay intensity (scale parameter)
+*/
+extern "C" __attribute__((visibility("default"))) __attribute__((used))
+void rgb_overlay(
+        uint8_t *starting_pointer,
+        int bitmap_length,
+        double red,
+        double green,
+        double blue,
+        double scale
+) {
+    for(int i = 0; i < bitmap_length; i += 4) {
+        uint8_t *r = starting_pointer + i;
+        uint8_t *g = starting_pointer + i + 1;
+        uint8_t *b = starting_pointer + i + 2;
+
+        *r = clamp255_0(round((*r - (*r - red) * scale)));
+        *g = clamp255_0(round((*g - (*g - green) * scale)));
+        *b = clamp255_0(round((*b - (*b - blue) * scale)));
+    }
+
+    return;
+}

--- a/lib/src/operation/crop.dart
+++ b/lib/src/operation/crop.dart
@@ -11,7 +11,7 @@ class BitmapCrop extends BitmapOperation {
     required this.top,
     required this.width,
     required this.height,
-  })   : assert(left >= 0),
+  })  : assert(left >= 0),
         assert(top >= 0),
         assert(width > 0),
         assert(height > 0);
@@ -21,7 +21,7 @@ class BitmapCrop extends BitmapOperation {
     required this.top,
     required int right,
     required int bottom,
-  })   : width = right - left,
+  })  : width = right - left,
         height = bottom - top;
 
   int left;

--- a/lib/src/operation/operation.dart
+++ b/lib/src/operation/operation.dart
@@ -6,6 +6,7 @@ export 'contrast.dart';
 export 'crop.dart';
 export 'flip.dart';
 export 'resize.dart';
+export 'rgb_overlay.dart';
 export 'rotation.dart';
 
 abstract class BitmapOperation {

--- a/lib/src/operation/rgb_overlay.dart
+++ b/lib/src/operation/rgb_overlay.dart
@@ -1,0 +1,50 @@
+import 'dart:ffi' as ffi;
+import 'dart:typed_data';
+
+import '../bitmap.dart';
+import '../ffi.dart';
+import 'operation.dart';
+
+// *** FFi C++ bindings ***
+const _nativeFunctionName = "rgb_overlay";
+
+typedef _NativeSideFunction = ffi.Void Function(ffi.Pointer<ffi.Uint8>,
+    ffi.Int32, ffi.Double, ffi.Double, ffi.Double, ffi.Double);
+
+typedef _DartSideFunction = void Function(
+    ffi.Pointer<ffi.Uint8> startingPointer,
+    int bitmapLength,
+    double red,
+    double green,
+    double blue,
+    double scale);
+
+_DartSideFunction _rgbOverlayFFIImpl = bitmapFFILib
+    .lookup<ffi.NativeFunction<_NativeSideFunction>>(_nativeFunctionName)
+    .asFunction();
+
+class BitmapRgbOverlay implements BitmapOperation {
+  BitmapRgbOverlay(this.red, this.green, this.blue, this.scale);
+
+  final double red;
+  final double green;
+  final double blue;
+  final double scale;
+
+  @override
+  Bitmap applyTo(Bitmap bitmap) {
+    final Bitmap copy = bitmap.cloneHeadless();
+    _rgbOverlayCore(copy.content, red, green, blue, scale);
+    return copy;
+  }
+
+  void _rgbOverlayCore(Uint8List sourceBmp, double red, double green,
+      double blue, double scale) {
+    final size = sourceBmp.length;
+
+    // start native execution
+    FFIImpl((startingPointer, pointerList) {
+      _rgbOverlayFFIImpl(startingPointer, size, red, green, blue, scale);
+    }).execute(sourceBmp);
+  }
+}


### PR DESCRIPTION
I implemented an operation for creating RGB overlays on a bitmap. 
This is useful for creating Instagram-like photo filters.